### PR TITLE
Create database table and controller for UCSBDiningCommonsMenuItem

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -1,0 +1,108 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+
+@Api(description = "UCSBDiningCommonsMenuItem")
+@RequestMapping("/api/UCSBDiningCommonsMenuItem")
+@RestController
+@Slf4j
+public class UCSBDiningCommonsMenuItemController extends ApiController {
+
+    @Autowired
+    UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
+
+    @ApiOperation(value = "List all the ~very tasty~ ucsb dining commons menu items")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<UCSBDiningCommonsMenuItem> allMenuItems() {
+        Iterable<UCSBDiningCommonsMenuItem> menuitems = ucsbDiningCommonsMenuItemRepository.findAll();
+        return menuitems;
+    }
+
+    @ApiOperation(value = "Get a single ucsb dining commons menu item")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public UCSBDiningCommonsMenuItem getById(
+            @ApiParam("id") @RequestParam Long id) {
+        UCSBDiningCommonsMenuItem menuitems = ucsbDiningCommonsMenuItemRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
+
+        return menuitems;
+    }
+
+    @ApiOperation(value = "Create a new ucsb dining commons menu item")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public UCSBDiningCommonsMenuItem postMenuItem(
+        @ApiParam("diningCommonsCode") @RequestParam String diningCommonsCode,
+        @ApiParam("name") @RequestParam String name,
+        @ApiParam("station") @RequestParam String station
+        )
+        {
+
+        UCSBDiningCommonsMenuItem menuitem = new UCSBDiningCommonsMenuItem();
+        menuitem.setDiningCommonsCode(diningCommonsCode);
+        menuitem.setName(name);
+        menuitem.setStation(station);
+
+        UCSBDiningCommonsMenuItem savedMenuItem = ucsbDiningCommonsMenuItemRepository.save(menuitem);
+
+        return savedMenuItem;
+    }
+    /*
+    @ApiOperation(value = "Delete a UCSBDiningCommons")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteCommons(
+            @ApiParam("code") @RequestParam String code) {
+        UCSBDiningCommons commons = ucsbDiningCommonsRepository.findById(code)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommons.class, code));
+
+        ucsbDiningCommonsRepository.delete(commons);
+        return genericMessage("UCSBDiningCommons with id %s deleted".formatted(code));
+    }
+
+    @ApiOperation(value = "Update a single commons")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public UCSBDiningCommons updateCommons(
+            @ApiParam("code") @RequestParam String code,
+            @RequestBody @Valid UCSBDiningCommons incoming) {
+
+        UCSBDiningCommons commons = ucsbDiningCommonsRepository.findById(code)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommons.class, code));
+
+
+        commons.setName(incoming.getName());  
+        commons.setHasSackMeal(incoming.getHasSackMeal());
+        commons.setHasTakeOutMeal(incoming.getHasTakeOutMeal());
+        commons.setHasDiningCam(incoming.getHasDiningCam());
+        commons.setLatitude(incoming.getLatitude());
+        commons.setLongitude(incoming.getLongitude());
+
+        ucsbDiningCommonsRepository.save(commons);
+
+        return commons;
+    }
+    */
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
@@ -1,0 +1,27 @@
+package edu.ucsb.cs156.example.entities;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Entity;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.GeneratedValue;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "ucsbdiningcommonsmenuitem")
+public class UCSBDiningCommonsMenuItem {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+  private String diningCommonsCode;
+  private String name;
+  private String station;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
@@ -1,0 +1,13 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+
+import org.springframework.beans.propertyeditors.StringArrayPropertyEditor;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface UCSBDiningCommonsMenuItemRepository extends CrudRepository<UCSBDiningCommonsMenuItem, Long> {
+ 
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
@@ -1,0 +1,320 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = UCSBDiningCommonsMenuItemController.class)
+@Import(TestConfig.class)
+public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase {
+
+        @MockBean
+        UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
+
+        @MockBean
+        UserRepository userRepository;
+
+        // Authorization tests for /api/UCSBDiningCommonsMenuItem/admin/all
+
+        @Test
+        public void logged_out_users_cannot_get_all() throws Exception {
+                mockMvc.perform(get("/api/UCSBDiningCommonsMenuItem/all"))
+                                .andExpect(status().is(403)); // logged out users can't get all
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_can_get_all() throws Exception {
+                mockMvc.perform(get("/api/UCSBDiningCommonsMenuItem/all"))
+                                .andExpect(status().is(200)); // logged
+        }
+
+        @Test
+        public void logged_out_users_cannot_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/UCSBDiningCommonsMenuItem?id=1"))
+                                .andExpect(status().is(403)); // logged out users can't get by id
+        }
+
+        // Authorization tests for /api/UCSBDiningCommonsMenuItem/post
+        // (Perhaps should also have these for put and delete)
+
+        @Test
+        public void logged_out_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/UCSBDiningCommonsMenuItem/post"))
+                                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_regular_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/UCSBDiningCommonsMenuItem/post"))
+                                .andExpect(status().is(403)); // only admins can post
+        }
+
+        // Tests with mocks for database actions
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+                // arrange
+
+                UCSBDiningCommonsMenuItem menuitem = UCSBDiningCommonsMenuItem.builder()
+                                .name("Mac n Cheese Pizza")
+                                .diningCommonsCode("DLG")
+                                .station("Pizza corner")
+                                .build();
+
+                when(ucsbDiningCommonsMenuItemRepository.findById(eq(1L))).thenReturn(Optional.of(menuitem));
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/UCSBDiningCommonsMenuItem?id=1"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(1L));
+                String expectedJson = mapper.writeValueAsString(menuitem);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+                // arrange
+
+                when(ucsbDiningCommonsMenuItemRepository.findById(eq(1L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/UCSBDiningCommonsMenuItem?id=1"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(1L));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("UCSBDiningCommonsMenuItem with id 1 not found", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_user_can_get_all_ucsbdiningcommonsmenuitems() throws Exception {
+
+                // arrange
+
+                UCSBDiningCommonsMenuItem menuitem = UCSBDiningCommonsMenuItem.builder()
+                                .name("Mac n Cheese Pizza")
+                                .diningCommonsCode("DLG")
+                                .station("Pizza corner")
+                                .build();
+
+                UCSBDiningCommonsMenuItem menuitem2 = UCSBDiningCommonsMenuItem.builder()
+                                .name("Raspberry Fizzy Water")
+                                .diningCommonsCode("Ortega")
+                                .station("Drinks table")
+                                .build();
+
+                ArrayList<UCSBDiningCommonsMenuItem> expectedMenuItems = new ArrayList<>();
+                expectedMenuItems.addAll(Arrays.asList(menuitem, menuitem2));
+
+                when(ucsbDiningCommonsMenuItemRepository.findAll()).thenReturn(expectedMenuItems);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/UCSBDiningCommonsMenuItem/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(ucsbDiningCommonsMenuItemRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedMenuItems);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_can_post_a_new_menu_item() throws Exception {
+                // arrange
+
+                UCSBDiningCommonsMenuItem menuitem = UCSBDiningCommonsMenuItem.builder()
+                                .name("Mac n Cheese Pizza")
+                                .diningCommonsCode("DLG")
+                                .station("Pizza corner")
+                                .build();
+
+                when(ucsbDiningCommonsMenuItemRepository.save(eq(menuitem))).thenReturn(menuitem);
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                post("/api/UCSBDiningCommonsMenuItem/post?name=Mac n Cheese Pizza&diningCommonsCode=DLG&station=Pizza corner")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(ucsbDiningCommonsMenuItemRepository, times(1)).save(menuitem);
+                String expectedJson = mapper.writeValueAsString(menuitem);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+        /*
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_delete_a_date() throws Exception {
+                // arrange
+
+                UCSBDiningCommons portola = UCSBDiningCommons.builder()
+                                .name("Portola")
+                                .code("portola")
+                                .hasSackMeal(true)
+                                .hasTakeOutMeal(true)
+                                .hasDiningCam(true)
+                                .latitude(34.417723)
+                                .longitude(-119.867427)
+                                .build();
+
+                when(ucsbDiningCommonsRepository.findById(eq("portola"))).thenReturn(Optional.of(portola));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/ucsbdiningcommons?code=portola")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(ucsbDiningCommonsRepository, times(1)).findById("portola");
+                verify(ucsbDiningCommonsRepository, times(1)).delete(any());
+
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("UCSBDiningCommons with id portola deleted", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_tries_to_delete_non_existant_commons_and_gets_right_error_message()
+                        throws Exception {
+                // arrange
+
+                when(ucsbDiningCommonsRepository.findById(eq("munger-hall"))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/ucsbdiningcommons?code=munger-hall")
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(ucsbDiningCommonsRepository, times(1)).findById("munger-hall");
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("UCSBDiningCommons with id munger-hall not found", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_edit_an_existing_commons() throws Exception {
+                // arrange
+
+                UCSBDiningCommons carrilloOrig = UCSBDiningCommons.builder()
+                                .name("Carrillo")
+                                .code("carrillo")
+                                .hasSackMeal(false)
+                                .hasTakeOutMeal(false)
+                                .hasDiningCam(true)
+                                .latitude(34.409953)
+                                .longitude(-119.85277)
+                                .build();
+
+                UCSBDiningCommons carrilloEdited = UCSBDiningCommons.builder()
+                                .name("Carrillo Dining Hall")
+                                .code("carrillo")
+                                .hasSackMeal(true)
+                                .hasTakeOutMeal(true)
+                                .hasDiningCam(false)
+                                .latitude(34.409954)
+                                .longitude(-119.85278)
+                                .build();
+
+                String requestBody = mapper.writeValueAsString(carrilloEdited);
+
+                when(ucsbDiningCommonsRepository.findById(eq("carrillo"))).thenReturn(Optional.of(carrilloOrig));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/ucsbdiningcommons?code=carrillo")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(ucsbDiningCommonsRepository, times(1)).findById("carrillo");
+                verify(ucsbDiningCommonsRepository, times(1)).save(carrilloEdited); // should be saved with updated info
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(requestBody, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_cannot_edit_commons_that_does_not_exist() throws Exception {
+                // arrange
+
+                UCSBDiningCommons editedCommons = UCSBDiningCommons.builder()
+                                .name("Munger Hall")
+                                .code("munger-hall")
+                                .hasSackMeal(false)
+                                .hasTakeOutMeal(false)
+                                .hasDiningCam(true)
+                                .latitude(34.420799)
+                                .longitude(-119.852617)
+                                .build();
+
+                String requestBody = mapper.writeValueAsString(editedCommons);
+
+                when(ucsbDiningCommonsRepository.findById(eq("munger-hall"))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/ucsbdiningcommons?code=munger-hall")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(ucsbDiningCommonsRepository, times(1)).findById("munger-hall");
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("UCSBDiningCommons with id munger-hall not found", json.get("message"));
+
+        }
+        */
+}


### PR DESCRIPTION
In this PR we create a database table for UCSBDiningCommonsMenuItem, implementing an `@Entity` class called UCSBDiningCommonsMenuItem.java and a `@Repository` class called UCSBDiningCommonsMenuItemRepository.java.

Closes #31 